### PR TITLE
Monotonic Time Source

### DIFF
--- a/src/lewiscowles/core/MonotonicTimeSource.java
+++ b/src/lewiscowles/core/MonotonicTimeSource.java
@@ -8,7 +8,7 @@ public final class MonotonicTimeSource implements TimeSourceInterface {
 
     private static long lastTime;
     private synchronized static long getTimeInternal() {
-        long now = System.nanoTime();
+        long now = System.currentTimeMillis();
         return (now > lastTime) ? lastTime=now : ++lastTime;
     }
 }

--- a/src/lewiscowles/core/MonotonicTimeSource.java
+++ b/src/lewiscowles/core/MonotonicTimeSource.java
@@ -1,0 +1,12 @@
+package lewiscowles.core;
+
+
+public final class MonotonicTimeSource implements TimeSourceInterface {
+    public long getTime() {
+        /*
+         * Note that this time-source returns a value very different,
+         * but should be non-colliding with SystemTimeSource
+         */
+        return System.nanoTime();
+    }
+}

--- a/src/lewiscowles/core/MonotonicTimeSource.java
+++ b/src/lewiscowles/core/MonotonicTimeSource.java
@@ -3,10 +3,12 @@ package lewiscowles.core;
 
 public final class MonotonicTimeSource implements TimeSourceInterface {
     public long getTime() {
-        /*
-         * Note that this time-source returns a value very different,
-         * but should be non-colliding with SystemTimeSource
-         */
-        return System.nanoTime();
+        return getTimeInternal();
+    }
+
+    private static long lastTime;
+    private synchronized static long getTimeInternal() {
+        long now = System.nanoTime();
+        return (now > lastTime) ? lastTime=now : ++lastTime;
     }
 }

--- a/test/lewiscowles/core/MonotonicTimeSourceTest.java
+++ b/test/lewiscowles/core/MonotonicTimeSourceTest.java
@@ -1,0 +1,17 @@
+package lewiscowles.core;
+
+import static org.junit.Assert.assertThat;
+
+import static org.hamcrest.Matchers.lessThan;
+
+import org.junit.Test;
+
+public class MonotonicTimeSourceTest {
+    @Test
+    public void monotonicTimeSourceAlwaysIncreases() {
+        TimeSourceInterface timeSource = new MonotonicTimeSource();
+        for (int i = 0; i < 1000000; i++) {
+          assertThat( timeSource.getTime(), lessThan(timeSource.getTime()) );
+        }
+    }
+}


### PR DESCRIPTION
Monotonic Time source for the library. Completed with the company and assistance of @andzandz and @dfourn for linking https://stackoverflow.com/questions/2978598/will-system-currenttimemillis-always-return-a-value-previous-calls/2979730#2979730 which to be clear is not the best way of doing this, but is a fast and easily readable one.

`system.getNanotime()` should have worked, but would not work in GitHub Actions. Likely due to the System not enforcing monotonic timings, which then cascades into Java, which simply wraps the system implementation. https://stackoverflow.com/a/51345008/1548557